### PR TITLE
Write git diff to text file

### DIFF
--- a/forge/experiment_tools.py
+++ b/forge/experiment_tools.py
@@ -41,6 +41,7 @@ from tensorflow.python import debug as tf_debug
 from forge import flags as _flags
 
 FLAG_FILE = 'flags.json'
+GIT_DIFF_FILE = 'git_diff.txt'
 
 
 def json_store(path, data):
@@ -197,6 +198,10 @@ def init_checkpoint(checkpoint_dir, data_config, model_config, resume):
             file_name = os.path.basename(src)
             dst = os.path.join(experiment_folder, file_name)
             shutil.copy(src, dst)
+
+        # write uncommited changes to text file
+        git_diff_file = os.path.join(experiment_folder, GIT_DIFF_FILE)
+        os.system('git diff > '+git_diff_file)
 
     return experiment_folder, resume_checkpoint
 

--- a/forge/experiment_tools.py
+++ b/forge/experiment_tools.py
@@ -201,7 +201,7 @@ def init_checkpoint(checkpoint_dir, data_config, model_config, resume):
 
         # write uncommited changes to text file
         git_diff_file = os.path.join(experiment_folder, GIT_DIFF_FILE)
-        os.system('git diff > '+git_diff_file)
+        os.system('git diff > ' + git_diff_file)
 
     return experiment_folder, resume_checkpoint
 


### PR DESCRIPTION
Make system call to write output of git diff to a text file for tracking any uncommitted changes.

Related to issue #10 