### PR TITLE
Print function that writes to both command line and text file

### DIFF
--- a/forge/experiment_tools.py
+++ b/forge/experiment_tools.py
@@ -42,6 +42,8 @@ from forge import flags as _flags
 
 FLAG_FILE = 'flags.json'
 GIT_DIFF_FILE = 'git_diff.txt'
+FPRINT_FILE = 'fprint.txt'
+EXPERIMENT_FOLDER = None
 
 
 def json_store(path, data):
@@ -202,6 +204,10 @@ def init_checkpoint(checkpoint_dir, data_config, model_config, resume):
         # write uncommited changes to text file
         git_diff_file = os.path.join(experiment_folder, GIT_DIFF_FILE)
         os.system('git diff > ' + git_diff_file)
+
+    # TODO(martin): Is there a way to avoid this global variable?
+    global EXPERIMENT_FOLDER
+    EXPERIMENT_FOLDER = experiment_folder
 
     return experiment_folder, resume_checkpoint
 
@@ -415,3 +421,14 @@ def get_session(tfdbg=False):
 
 def set_gpu(gpu_num):
     os.environ['CUDA_VISIBLE_DEVICES'] = gpu_num
+
+
+def fprint(text):
+    """Print text to screen and write to FPRINT_FILE."""
+    # Redirect stdout to file
+    original = sys.stdout
+    sys.stdout = open(os.path.join(EXPERIMENT_FOLDER, FPRINT_FILE), 'a+')
+    print(text)
+    # Set stdout back to original
+    sys.stdout = original
+    print(text)


### PR DESCRIPTION
Add an fprint function (shorthand for either file print or Forge print) that works like print() but also appends the input string to an experiment specific text file.

(See issue #2 )